### PR TITLE
meta-qt4/qt4: enable pkgconfig and switch comparison to ptr

### DIFF
--- a/recipes-qt4/qt4/qt4-4.8.7.inc
+++ b/recipes-qt4/qt4/qt4-4.8.7.inc
@@ -30,6 +30,7 @@ SRC_URI = "http://download.qt-project.org/archive/qt/4.8/${PV}/qt-everywhere-ope
            file://0037-fix-configure-with-icu60.patch \
            file://0038-prevent-gcc-9.2-miscompiling-Q_FOREACH.patch \
            file://0039-silence-some-loud-but-innocent-warnings.patch \
+           file://0040-qt4-x11-free-messagemodel.cpp-comparison-patch.patch \
            file://gcc-version.patch \
            file://Fix-QWSLock-invalid-argument-logs.patch \
            file://add_check_for_aarch64_32.patch \

--- a/recipes-qt4/qt4/qt4-4.8.7/0040-qt4-x11-free-messagemodel.cpp-comparison-patch.patch
+++ b/recipes-qt4/qt4/qt4-4.8.7/0040-qt4-x11-free-messagemodel.cpp-comparison-patch.patch
@@ -1,0 +1,26 @@
+From fe547089114307b086167639066a1551cec39d11 Mon Sep 17 00:00:00 2001
+From: Edi Feschiyan <edi.feschiyan@konsulko.com>
+Date: Fri, 20 Oct 2023 11:13:28 +0000
+Subject: [PATCH] qt4-x11-free: messagemodel.cpp comparison patch
+
+Switching comparison from a pointer with integer
+to pointer with (void *)pointer comparison
+
+Signed-off-by: Edi Feschiyan <edi.feschiyan@konsulko.com>
+---
+ tools/linguist/linguist/messagemodel.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/linguist/linguist/messagemodel.cpp b/tools/linguist/linguist/messagemodel.cpp
+index 61c5389f..86bbe04f 100644
+--- a/tools/linguist/linguist/messagemodel.cpp
++++ b/tools/linguist/linguist/messagemodel.cpp
+@@ -183,7 +183,7 @@ static int calcMergeScore(const DataModel *one, const DataModel *two)
+         if (ContextItem *c = one->findContext(oc->context())) {
+             for (int j = 0; j < oc->messageCount(); ++j) {
+                 MessageItem *m = oc->messageItem(j);
+-                if (c->findMessage(m->text(), m->comment()) >= 0)
++                if (c->findMessage(m->text(), m->comment()) >= (void *)0)
+                     ++inBoth;
+             }
+         }

--- a/recipes-qt4/qt4/qt4-native.inc
+++ b/recipes-qt4/qt4/qt4-native.inc
@@ -20,6 +20,7 @@ SRC_URI = "http://download.qt-project.org/archive/qt/4.8/${PV}/qt-everywhere-ope
            file://0036-qt-everywhere-opensource-src-4.8.7-gcc6.patch \
            file://0038-prevent-gcc-9.2-miscompiling-Q_FOREACH.patch \
            file://0039-silence-some-loud-but-innocent-warnings.patch \
+           file://0040-qt4-x11-free-messagemodel.cpp-comparison-patch.patch \
            file://gcc-version.patch \
            file://g++.conf \
            file://linux.conf \


### PR DESCRIPTION
Adds the patch to switch comparison from  >= 0 to >= (void *)0 and inherit pkgconfig in qt4-x11-free.inc